### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,11 +10,11 @@ Dependencies
 
 Mandatory Dependencies:
 
-    apt_file - for figuring out what packages provide certain files
+    apt-file - for figuring out what packages provide certain files
 
 Optional Dependencies:
 
-    pyyaml - enables yaml lint
+    python3-yaml - enables yaml lint
 
 Installation
 ------------


### PR DESCRIPTION
Include the debian package names in the tool documentation. This is because the tool would be ran on tkldev operation system for most situations. Therefore, I think it would be the most beneficial to the end users to have the debian package names in the installation process documentation.