### PR TITLE
Tweak

### DIFF
--- a/bin/tkldev-changelog
+++ b/bin/tkldev-changelog
@@ -1,0 +1,186 @@
+#!/bin/bash -e
+# Copyright (c) 2017 TurnKey GNU/Linux - http://www.turnkeylinux.org
+# 
+# tkldev-changelog
+# ----------------
+# A tool to easily update turnkey appliance changelogs
+#
+# This file is part of tkldev-tools.
+# 
+# tkldev-tools is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+
+fatal() { echo "FATAL [$(basename $0)]: $@" 1>&2; exit 1; }
+warning() { echo "WARNING [$(basename $0)]: $@"; }
+info() { echo "INFO [$(basename $0)]: $@"; }
+
+usage() {
+    if [[ $# -ne 0 ]]; then
+        echo "ERROR: $@"
+        echo
+        exit_code=1
+    fi
+cat<<EOF
+Syntax: $(basename $0) [appliance-name]
+When run in the root directory of an appliance's source code, this script will
+create a new changelog entry at the top of an existing changelog file & opens
+the file for editing in vim.
+
+Prerequisites:
+
+    devscripts (debian package - hard dependency)
+    vim (debian package - optional; vim-tiny is pre-installed and will work)
+    configured local tz-data (optional - otherwise will fall back to UTC)
+
+Arguments::
+
+    appliance-name      - e.g., core
+    -a|--author         - Update the author name and email address of the most
+                          recent entry (do not leave open for editing).
+    -d|--date           - Update the date of the most recent entry (do not
+                          leave open for editing).
+    -e|--edit           - Edit the most recent entry (rather than generating a
+                          new one) - implies -d|--date & -n|--name, but leaves
+                          open for editing.
+    -n|--new-minor      - Create new minor version changelog entry (e.g. 16.1).
+                          Leaves open for editing. (Default action if no switch
+                          specified).
+    -N|--new-major      - Create new major version changelog entry (e.g. 17.0).
+                          Leaves open for editing.
+
+Environment::
+
+    DEBFULLNAME         - full name of operator e.g. "Joe Bloggs"
+    FULLNAME            - full name of operator (if DEBFULLNAME not set)
+    DEBEMAIL            - email address of operator e.g. "joe@blogs.com"
+    EMAIL               - email address of operator (if DEBEMAIL not set)
+    EXTRA_TEXT          - additional changelog points to include in new entry
+                          if not set; then by default it will read from 
+                          "/turnkey/fab/products/common-changes"
+    DEVDEBUG            - turn on debugging
+
+Future plans:
+
+    - create new changelog (probably via switch?)
+    - support specifiying a path (currently must be run in root of appliance
+      source code)
+    - do something better with the EXTRA_TEXT (e.g. include in common?)
+    - support alternate text editors?
+
+EOF
+    exit $exit_code
+}
+
+[[ -z "$DEVDEBUG" ]] || set -x
+which dch > /dev/null || fatal "dch not found; please install 'devscripts'"
+which vim > /dev/null || fatal "vim not found; call yourself a developer?!?"
+[ -f changelog ] || fatal "no changelog in local dir"
+
+APP=$(basename $PWD)
+COMMON_CHANGES="${FAB_PATH}/products/common-changes"
+COMMON_CHANGE_CHECKS=("lapp.mk" "lamp.mk" "nodejs.mk")
+
+if [ -z "$EXTRA_TEXT" ] && [ "$APP" != "core" ]; then
+    EXTRA_TEXT=""
+    for change_check in ${COMMON_CHANGE_CHECKS[@]}; do
+        if grep -Fq "$change_check" Makefile; then
+            change_fn="${COMMON_CHANGES}/${change_check%.mk}"
+            if [ -f "$change_fn" ]; then
+                EXTRA_TEXT="${EXTRA_TEXT}$(cat "$change_fn")"$'\n\n'
+            else
+                echo "error: common change \"$change_fn\" not found!"
+                echo "Ignoring..."
+                #exit 1
+            fi
+        fi
+    done
+
+    EXTRA_TEXT+="$(cat "${COMMON_CHANGES}/base" 2>/dev/null)"$'\n' \
+        || true
+fi
+
+EXTRA_TEXT_FILE="$(mktemp /tmp/tkldev-changelog.XXXXXX)"
+trap "rm -f $EXTRA_TEXT_FILE" EXIT
+echo "$EXTRA_TEXT" > "$EXTRA_TEXT_FILE"
+
+author_name=${FULLNAME:-$DEBFULLNAME}
+author_email=${EMAIL:-$DEBEMAIL}
+
+unset set_author set_date new_min_set new_maj_set new edit
+if [[ $# -eq 0 ]]; then
+    # if no args; then default to '-n|--new-minor'
+    new_min_set=1
+    new=minor
+    edit=y
+fi
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage;;
+        -a|--author)
+            set_author=y
+            edit=n
+            shift;;
+        -d|--date)
+            set_date=y
+            edit=n
+            shift;;
+        -e|--edit)
+            set_author=y
+            set_date=y
+            edit=y
+            shift;;
+        -n|--new-minor)
+            new_min_set=1
+            new=minor
+            edit=y
+            shift;;
+        -N|--new-major)
+            new_maj_set=1
+            new=major
+            edit=y
+            shift;;
+    esac
+done
+
+OLD_VER=$(head -1 changelog | cut -d' ' -f1 | sed "s|^.*${APP}-||")
+MAJ="$(echo ${OLD_VER} | cut -d. -f1)"
+MIN="$(echo ${OLD_VER} | cut -d. -f2)"
+
+if [[ -n "$new_min_set" ]] && [[ -n "$new_maj_set" ]]; then
+    usage "-n|--new-minor & -N|--new-major can't both be set; doesn't make sense."
+elif [[ "$new" == 'minor' ]]; then
+    MIN="$(( $(echo ${OLD_VER} | cut -d. -f2) +1 ))"
+elif [[ "$new" == 'major' ]]; then
+    MAJ=$(( $MAJ +1 ))
+    MIN=0
+fi
+
+NEW_VER=${MAJ}.${MIN}
+NAME="turnkey-${APP}-${NEW_VER}"
+
+OLD_FILE="$(cat changelog)"
+
+if [[ -n "$set_date" ]]; then
+    dch --changelog changelog --release --force-distribution turnkey --urgency low
+fi
+if [[ -n "$set_author" ]]; then
+    sed -i "0,\|^ -- |s|^.*> \(.*\)| -- $author_name <$author_email> \1|" changelog
+fi
+if [[ "$edit" == 'y' ]]; then
+    if [[ -n "$new" ]]; then
+        dch --changelog changelog --release-heuristic log --package $NAME --newversion 1 --force-distribution turnkey --urgency low
+        sed -i "3s|\*.*|\* |" changelog
+        sed -e "4r ${EXTRA_TEXT_FILE}" -i changelog
+    else
+        sed -i '3i\ \ * \n' changelog
+    fi
+    OLD_HASH="$(sha512sum changelog)"
+    vim "+call cursor(3, 7)" changelog
+    if echo "$OLD_HASH" | sha512sum -c --status; then
+        echo "no changes made, reverting"
+        echo "$OLD_FILE" > changelog
+    fi
+fi

--- a/bin/tkldev-changelog
+++ b/bin/tkldev-changelog
@@ -58,7 +58,7 @@ Environment::
     EMAIL               - email address of operator (if DEBEMAIL not set)
     EXTRA_TEXT          - additional changelog points to include in new entry
                           if not set; then by default it will read from 
-                          "/turnkey/fab/products/common-changes"
+                          "/turnkey/fab/common/changes"
     DEVDEBUG            - turn on debugging
 
 Future plans:
@@ -79,26 +79,11 @@ which vim > /dev/null || fatal "vim not found; call yourself a developer?!?"
 [ -f changelog ] || fatal "no changelog in local dir"
 
 APP=$(basename $PWD)
-COMMON_CHANGES="${FAB_PATH}/products/common-changes"
-COMMON_CHANGE_CHECKS=("lapp.mk" "lamp.mk" "nodejs.mk")
+COMMON_CHANGES="${FAB_PATH}/common/changes"
+APP_CHANGELOGS="$(tkldev-makefile-info "$PWD/Makefile"  -i | grep '/turnkey/fab/common' | rev | cut -d '/' -f 1 | rev | sed -E "s|^(.*).mk$|/${FAB_PATH}/common/changes/\1.changelog|")"
 
 if [ -z "$EXTRA_TEXT" ] && [ "$APP" != "core" ]; then
-    EXTRA_TEXT=""
-    for change_check in ${COMMON_CHANGE_CHECKS[@]}; do
-        if grep -Fq "$change_check" Makefile; then
-            change_fn="${COMMON_CHANGES}/${change_check%.mk}"
-            if [ -f "$change_fn" ]; then
-                EXTRA_TEXT="${EXTRA_TEXT}$(cat "$change_fn")"$'\n\n'
-            else
-                echo "error: common change \"$change_fn\" not found!"
-                echo "Ignoring..."
-                #exit 1
-            fi
-        fi
-    done
-
-    EXTRA_TEXT+="$(cat "${COMMON_CHANGES}/base" 2>/dev/null)"$'\n' \
-        || true
+    EXTRA_TEXT="$(tkldev-changelog-extractor "$PWD/changelog" $APP_CHANGELOGS)"
 fi
 
 EXTRA_TEXT_FILE="$(mktemp /tmp/tkldev-changelog.XXXXXX)"

--- a/bin/tkldev-changelog-extractor
+++ b/bin/tkldev-changelog-extractor
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+from subprocess import check_output
+from os.path import isfile
+import sys
+import re
+
+CHANGE_HEAD=r'^turnkey-.*-(\d+)\.(\d+)-?(?:rc|beta)? \((\d+)\) .*$'
+CHANGE_FOOTER=r' -- .*'
+
+def error(msg):
+    print('ERROR: ' + msg, file=sys.stderr)
+def warn(msg):
+    print('WARN: ' + msg, file=sys.stderr)
+
+def process_changelog(path):
+    if not isfile(path):
+        warn(f"changelog {path} does not exist!")
+        return {}
+    changes = {}
+    current_v = None
+    skip = False
+
+    with open(path, 'r') as fob:
+        for line in fob:
+            matched = re.match(CHANGE_HEAD, line)
+            if matched:
+                major, minor, rel = matched.groups()
+                if len(major) > 3:
+                    skip = True
+                    continue
+                v = (int(major), int(minor), int(rel))
+                if v in changes:
+                    warn(f"duplicate version: {v}, condensing duplicate entries")
+                    current_v = v
+                    continue
+                assert v not in changes
+                changes[v] = []
+                current_v = v
+                continue
+
+            matched = re.match(CHANGE_FOOTER, line)
+            if matched:
+                current_v = None
+                skip = False
+                continue
+
+            if skip:
+                continue
+
+            if not line.strip():
+                continue
+
+            assert current_v is not None
+            if line.startswith('  *'):
+                changes[current_v].append(line)
+            else:
+                changes[current_v][-1] += line
+    return changes
+
+if __name__ == '__main__':
+    parser = ArgumentParser(description='''
+    tool for extracting changelog entries from one or more "common" changelogs
+    without duplicates.
+
+    Given some "changelog" and one or more "common" changelogs, take entries
+    from each common changelog which are newer than some version "from", but not
+    in the primary changelog.
+
+    ''')
+    parser.add_argument('-f', '--from',
+            help='only process entries more recent than this version (defaults to release of this tkldev)',
+            default=None,
+            metavar='MAJOR[.MINOR[.RELEASE]]',
+            dest='from_v')
+    parser.add_argument('changelog',
+            help='the changelog you\'re extracting entries for')
+    parser.add_argument('common',
+            help='return entries from these changelogs, not present in the primary changelog',
+            nargs='+')
+
+    args = parser.parse_args()
+
+    if args.from_v is None:
+        from_v = check_output(['turnkey-version', '-t'], text=True).strip()
+        if from_v.endswith('beta'):
+            from_v = from_v[:-4]
+        elif from_v.endswith('rc'):
+            from_v = from_v[:-2]
+    else:
+        from_v = args.from_v
+    if '.' in from_v:
+        from_v = from_v.split('.')
+        from_v = (*from_v, '0', '0')
+        if len(from_v) > 3:
+            from_v = from_v[:3]
+        from_v = tuple(map(int, from_v))
+    else:
+        from_v = (int(from_v), 0, 0)
+
+    # parse the changelog changes
+    primary = process_changelog(args.changelog)
+    common = [process_changelog(path) for path in args.common]
+    common_keys = set()
+    for chlg in common:
+        common_keys |= chlg.keys()
+
+    # remove entries older than some version
+    for key in primary.keys() | common_keys:
+        maj, min, rel = key
+        if (int(maj), int(min), int(rel)) < from_v:
+            if key in primary:
+                del primary[key]
+            for chlg in common:
+                if key in chlg:
+                    del chlg[key]
+
+    #all_primary_changes = [v for v in changes for changes in primary.values()]
+    all_primary_changes = [v for changes in primary.values() for v in changes]
+
+    for chlg in common:
+        for key in chlg.keys():
+            for change in chlg[key]:
+                if change not in all_primary_changes:
+                    print(change)
+
+    # output different changes
+    #print(json.dumps(changes, indent=4))

--- a/bin/tkldev-makefile-info
+++ b/bin/tkldev-makefile-info
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import json
+from argparse import ArgumentParser
+
+try:
+    from libtkldet import mkparser
+except ImportError:
+    print("tkldev-detective not installed (required for makefile parser)",
+        file=sys.stderr)
+    os.exit(1)
+    
+
+if __name__ == '__main__':
+    parser = ArgumentParser(description='''
+Tool for getting variables and includes from makefiles.
+
+Mostly specialized for turnkey usage (cuts corners that might cause issues in
+broader applications)
+''')
+    parser.add_argument('makefile', metavar='path/to/Makefile')
+
+    selection_group = parser.add_mutually_exclusive_group()
+    selection_group.add_argument('-a', '--all',
+        help='(default) show everything', action='store_true')
+    selection_group.add_argument('-v', '--var', nargs='?',
+        metavar='VARNAME', const=True,
+        help='show all variables or specific variable if specified')
+    selection_group.add_argument('-i', '--included',
+        help='show all included', action='store_true')
+
+    format_group = parser.add_mutually_exclusive_group()
+
+    format_group.add_argument('-s', '--shell', help='output in a shell friendly way')
+    format_group.add_argument('-j', '--json', help='output json')
+
+    parser.add_argument('-d', '--shell-delim', default=':',
+        help='delimiter to use with shell output')
+
+    args = parser.parse_args()
+
+    
+    if args.json:
+        def dump(v, prefix=None):
+            return json.dumps(v, indent=4)
+    else:
+        def dump(v, prefix=None):
+            no_prefix = prefix is None
+            if no_prefix:
+                prefix = []
+            out = []
+            if isinstance(v, dict):
+                for k, vs in v.items():
+                    out.extend(dump(vs, [*prefix, k]))
+            elif isinstance(v, list):
+                for v in v:
+                    out.extend(dump(v, prefix))
+            elif isinstance(v, str):
+                out.append(':'.join([*prefix, v]))
+            else:
+                raise TypeError(
+                    "don't know how to format {type(v)} in a shell friendly way")
+            if no_prefix:
+                return '\n'.join(out)
+            else:
+                return out
+
+    data = mkparser.parse_makefile(args.makefile).to_dict()
+
+    if args.var:
+        if isinstance(args.var, str):
+            if args.var in data['variables']:
+                print(dump(data['variables'][args.var]))
+            else:
+                print("variable not found", file=sys.stderr)
+        else:
+            print(dump(data['variables']))
+    elif args.included:
+        print(dump(data['included']))
+    else:
+        print(dump(data))

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,8 @@ Architecture: all
 Depends:
     ${python:Depends},
     shellcheck,
-    pylint
+    pylint,
+    devscripts,
 Recommends:
     python3-yaml
 Description: linter for turnkeylinux appliances

--- a/debian/install
+++ b/debian/install
@@ -1,0 +1,1 @@
+bin/*	usr/bin/

--- a/debian/install
+++ b/debian/install
@@ -1,1 +1,2 @@
-bin/*	usr/bin/
+bin/*	        usr/bin/
+tkldet_modules  usr/share/tkldev-detective/

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DH_ALWAYS_EXCLUDE=.pyc:.pyo
 
 %:
 	dh $@ --with=python3 --buildsystem=pybuild

--- a/libtkldet/apt_file.py
+++ b/libtkldet/apt_file.py
@@ -23,9 +23,13 @@ import subprocess
 
 def is_installed(package_name: str) -> bool:
     """check if a given package is installed on the HOST system (tkldev)"""
-    return b"installed" in subprocess.check_output(
-        ["dpkg-query", "-W", "--showformat='${Status}'\n", package_name]
-    )
+    pkg_installed = subprocess.run(
+        ["dpkg-query", "-W", "--showformat='${Status}'", package_name]
+        )
+    if pkg_installed.returncode == 0:
+        return True
+    else:
+        return False
 
 
 HAS_APT_FILE: bool = is_installed("apt-file")

--- a/libtkldet/apt_file.py
+++ b/libtkldet/apt_file.py
@@ -26,10 +26,7 @@ def is_installed(package_name: str) -> bool:
     pkg_installed = subprocess.run(
         ["dpkg-query", "-W", "--showformat='${Status}'", package_name]
         )
-    if pkg_installed.returncode == 0:
-        return True
-    else:
-        return False
+    return pkg_installed.returncode != 0
 
 
 HAS_APT_FILE: bool = is_installed("apt-file")

--- a/libtkldet/modman.py
+++ b/libtkldet/modman.py
@@ -19,11 +19,15 @@
 
 import importlib.machinery
 import importlib.util
-from os.path import join, dirname, abspath, splitext, isfile
+from os.path import join, dirname, abspath, splitext, isfile, exists
 from os import listdir
 import sys
 
 from . import colors as co
+from .error import TKLDevDetectiveError
+
+# priortise local tkldet_modules path, fallback to OS path
+MOD_PATH = [ abspath(__file__), '/usr/share/tkldev-detective']
 
 
 def _load_all_modules_from_dir(root: str):
@@ -46,6 +50,8 @@ def _load_all_modules_from_dir(root: str):
 
 def load_modules():
     """load all tkldev-detective modules"""
-    _load_all_modules_from_dir(
-        join(dirname(dirname(abspath(__file__))), "tkldet_modules")
-    )
+    for _path in (join(x, "tkldet_modules") for x in MOD_PATH):
+        if exists(_path):
+            _load_all_modules_from_dir(_path)
+            return
+    raise TKLDevDetectiveError(f"Mod path 'tkldet_modules' not found - tried {MOD_PATH}")

--- a/libtkldet/modman.py
+++ b/libtkldet/modman.py
@@ -27,7 +27,7 @@ from . import colors as co
 from .error import TKLDevDetectiveError
 
 # priortise local tkldet_modules path, fallback to OS path
-MOD_PATH = [ abspath(__file__), '/usr/share/tkldev-detective']
+MOD_PATH = [ dirname(dirname(abspath(__file__))), '/usr/share/tkldev-detective']
 
 
 def _load_all_modules_from_dir(root: str):


### PR DESCRIPTION
Tweaks to tkldev-detective to get the package installable and working.

Happy to further discuss my code changes to tkldev-detective @OnGle. E.g. if you want rationale for anything and/or are unhappy with anything.

Note that this code is currently installable from the `bookworm-testing` repo. But be sure to remove the default `tkldev-changelog` in v18.0rc1 (`rm /usr/local/bin/tkldev-changelog`). It will be removed for v18.0 proper.