### PR TITLE
Force pybuild to not create __pycache__ files at build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,6 @@
 #!/usr/bin/make -f
 
-export DEB_BUILD_MAINT_OPTIONS = hardening=+all
-export DH_ALWAYS_EXCLUDE=.pyc:.pyo
+export PYTHONDONTWRITEBYTECODE=1
 
 %:
 	dh $@ --with=python3 --buildsystem=pybuild


### PR DESCRIPTION
Minimal change to make tkldev-detective reproducible - although it looks like this one probably already was via a different method! Regardless, I've still made the change here because IMO the result is cleaner this way because the directory and files are never created - rather than excluding the files at "install" time (and probably still including the empty dir).

FYI `DEB_BUILD_MAINT_OPTIONS` are only relevant to packages that are built from C/C++ source and have no impact on pure python source.